### PR TITLE
enhanced the product grid export button feature  to export the select…

### DIFF
--- a/Model/Export/ConvertToCsv.php
+++ b/Model/Export/ConvertToCsv.php
@@ -28,6 +28,7 @@ class ConvertToCsv extends \Magento\Ui\Model\Export\ConvertToCsv
         $stream = $this->directory->openFile($file, 'w+');
         $stream->lock();
         $stream->writeCsv($this->metadataProvider->getHeaders($component));
+        $columnsWithType= $this->metadataProvider->getColumnsWithDataType($component);
         $page = 1;
 
         $searchResult = $dataProvider->getSearchResult()
@@ -37,7 +38,7 @@ class ConvertToCsv extends \Magento\Ui\Model\Export\ConvertToCsv
         $items = LazySearchResultIterator::getGenerator($searchResult);
         foreach ($items as $item) {
             $this->metadataProvider->convertDate($item, $component->getName());
-            $stream->writeCsv($this->metadataProvider->getRowData($item, $fields, []));
+            $stream->writeCsv($this->metadataProvider->getRowDataBasedOnColumnType($item, $fields, $columnsWithType, []));
         }
 
         $stream->unlock();

--- a/Model/Export/ConvertToXls.php
+++ b/Model/Export/ConvertToXls.php
@@ -13,6 +13,10 @@ use Magento\Ui\Model\Export\SearchResultIteratorFactory;
 class ConvertToXls extends ConvertToXml
 {
 
+    protected $fields;
+    
+    protected $columnsWithType;
+
     /**
      * Returns XLS file
      *
@@ -30,6 +34,9 @@ class ConvertToXls extends ConvertToXml
         $this->filter->applySelectionOnTargetProvider();
         $dataProvider = $component->getContext()->getDataProvider();
 
+        $this->columnsWithType= $this->metadataProvider->getColumnsWithDataType($component);
+        $this->fields = $this->metadataProvider->getFields($this->filter->getComponent());
+
         // Force all results
         $searchResult = $dataProvider->getSearchResult()
             ->setCurPage(1)
@@ -37,7 +44,7 @@ class ConvertToXls extends ConvertToXml
 
         $excel = $this->excelFactory->create([
             'iterator' => LazySearchResultIterator::getGenerator($searchResult),
-            'rowCallback'=> [$this, 'getRowData'],
+            'rowCallback'=> [$this, 'getRowDataBasedOnColumnType'],
         ]);
 
         $this->directory->create('export');
@@ -54,6 +61,10 @@ class ConvertToXls extends ConvertToXml
             'value' => $file,
             'rm' => true  // can delete file after use
         ];
+    }
+
+    public function getRowDataBasedOnColumnType($item) {
+        return $this->metadataProvider->getRowDataBasedOnColumnType($item, $this->fields, $this->columnsWithType, []);
     }
 
     public function getRowData($item) : array{

--- a/Model/Export/ConvertToXml.php
+++ b/Model/Export/ConvertToXml.php
@@ -12,6 +12,9 @@ use Magento\Ui\Model\Export\SearchResultIteratorFactory;
 
 class ConvertToXml extends ParentConvertToXml
 {
+    protected $fields;
+
+    protected $columnsWithType;
 
     /**
      * Returns XML file
@@ -30,6 +33,10 @@ class ConvertToXml extends ParentConvertToXml
         $this->filter->applySelectionOnTargetProvider();
         $dataProvider = $component->getContext()->getDataProvider();
 
+        $this->columnsWithType= $this->metadataProvider->getColumnsWithDataType($component);
+        $this->fields = $this->metadataProvider->getFields($this->filter->getComponent());
+
+
         // Force all results
         $searchResult = $dataProvider->getSearchResult()
             ->setCurPage(1)
@@ -37,9 +44,8 @@ class ConvertToXml extends ParentConvertToXml
 
         $excel = $this->excelFactory->create([
             'iterator' => LazySearchResultIterator::getGenerator($searchResult),
-            'rowCallback'=> [$this, 'getRowData'],
+            'rowCallback'=> [$this, 'getRowDataBasedOnColumnType'],
         ]);
-
         $this->directory->create('export');
         $stream = $this->directory->openFile($file, 'w+');
         $stream->lock();
@@ -54,6 +60,10 @@ class ConvertToXml extends ParentConvertToXml
             'value' => $file,
             'rm' => true  // can delete file after use
         ];
+    }
+
+    public function getRowDataBasedOnColumnType($item) {
+        return $this->metadataProvider->getRowDataBasedOnColumnType($item, $this->fields, $this->columnsWithType, []);
     }
 
     public function getRowData($item) : array{

--- a/Model/Export/MetadataProvider.php
+++ b/Model/Export/MetadataProvider.php
@@ -7,6 +7,8 @@ use Magento\Ui\Component\MassAction\Filter;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Ui\Model\BookmarkManagement;
+use Magento\Eav\Api\AttributeSetRepositoryInterface as AttributeSetRepository;
+use Magento\Store\Api\WebsiteRepositoryInterface as WebsiteRepository;
 
 class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
 {
@@ -15,6 +17,15 @@ class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
      */
     protected $_bookmarkManagement;
 
+    protected $attributeSetRepository;
+
+    protected $websiteRepository;
+
+    /**
+     * @var array $columnsType
+     */
+    protected $columnsType;
+
     /**
      * MetadataProvider constructor.
      * @param Filter $filter
@@ -22,6 +33,8 @@ class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
      * @param ResolverInterface $localeResolver
      * @param string $dateFormat
      * @param BookmarkManagement $bookmarkManagement
+     * @param AttributeSetRepository $attributeSetRepository 
+     * @param WebsiteRepository $websiteRepository  
      * @param array $data
      */
     public function __construct(
@@ -29,11 +42,15 @@ class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
         TimezoneInterface $localeDate,
         ResolverInterface $localeResolver,
         BookmarkManagement $bookmarkManagement,
+        AttributeSetRepository $attributeSetRepository,
+        WebsiteRepository $websiteRepository,  
         $dateFormat = 'M j, Y H:i:s A',
         array $data = [])
     {
         parent::__construct($filter, $localeDate, $localeResolver, $dateFormat, $data);
         $this->_bookmarkManagement = $bookmarkManagement;
+        $this->attributeSetRepository = $attributeSetRepository;
+        $this->websiteRepository = $websiteRepository;
     }
 
     protected function getActiveColumns($component){
@@ -74,9 +91,63 @@ class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
         return $this->columns[$component->getName()];
     }
 
+    /**
+     * @param UiComponentInterface $component
+     * @return string[]
+     * @throws \Exception
+     */
+    public function getColumnsWithDataType(UiComponentInterface $component) : array
+    {
+        $this->columnsType = [];
+        $activeColumns = $this->getActiveColumns($component);
+        $columns = $this->getColumnsComponent($component);
+        $components = $columns->getChildComponents();
+
+        foreach ($activeColumns as $columnName) {
+            $column = $components[$columnName] ?? null;
+            if (isset($column) && $column->getData('config/label') && $column->getData('config/dataType') !== 'actions') {
+                $this->columnsType[$column->getName()] = $column->getData('config/dataType');            
+            }
+        }
+        return $this->columnsType;
+    }
+
+
+    /**
+     * 
+     * @param \Magento\Catalog\Model\Product $document
+     * @param string[] $fields
+     * @param string[] $columnsType
+     * 
+     * @return array 
+     * 
+     */
+    public function getRowDataBasedOnColumnType($document, $fields, $columnsType, $options): array{
+        $rowData = array_values(
+            array_map(
+                function($field) use ($columnsType,$document) {
+                    if ($field == 'attribute_set_id') {
+                        $columnData = $this->getAttributeSetName($document, $field);
+                    } elseif ($field == 'websites') {
+                        $columnData = $this->getWebsiteName($document, $field);
+                    } elseif (isset($columnsType[$field]) && $columnsType[$field] == 'select')  {
+                        // $columnData = $this->handleSelectField($document, $field);
+                        $columnData = (trim($document->getAttributeText($field))) ? trim($document->getAttributeText($field)) : $this->getColumnData($document, $field);  
+                    } elseif (isset($columnsType[$field]) && $columnsType[$field] == 'multiselect')  {
+                        $columnData = is_array($document->getAttributeText($field)) ? implode(',',$document->getAttributeText($field)) : $document->getAttributeText($field);
+                    } else {
+                        $columnData = $this->getColumnData($document, $field);
+                    }
+                    return $columnData;
+                }, 
+            $fields)
+        );
+        return $rowData;
+    }
 
     public function getRowData($document, $fields, $options): array{
-        return array_values(array_map(fn($field) => $this->getColumnData($document, $field), $fields));
+        $rowData = array_values(array_map(fn($field) => $this->getColumnData($document, $field), $fields));
+        return $rowData;
     }
 
     public function getColumnData($document, $field)
@@ -89,4 +160,57 @@ class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
 
         return $value;
     }
+
+    /**
+     * 
+     * handler of select fields attribute
+     * 
+     * @param \Magento\Catalog\Model\Product $_productItem
+     * @param string $field
+     * 
+     * @return string $columnData
+     * 
+     */
+    protected function handleSelectField(\Magento\Catalog\Model\Product $_productItem, string $field):string {
+        if (trim($_productItem->getAttributeText($field))) {
+            $columnData = trim($_productItem->getAttributeText($field)); 
+        }  else {
+            $columnData = $this->getColumnData($_productItem, $field);
+        }
+        return (string) $columnData;
+    }
+
+
+    /**
+     * 
+     * @param \Magento\Catalog\Model\Product $_productItem
+     * @param string $field
+     * 
+     * @return string $attributeSetName
+     * 
+     */
+    protected function getAttributeSetName(\Magento\Catalog\Model\Product $_productItem, string $field):string {
+        $attributeSetId = $_productItem->getData($field);
+        /** @var $_attributeSet \Magento\Eav\Api\Data\AttributeSetInterface */
+        $_attributeSet = $this->attributeSetRepository->get($attributeSetId);
+        $attributeSetName = ($_attributeSet) ? $_attributeSet->getAttributeSetName() : '';
+        return $attributeSetName;
+    }
+
+    /**
+     * 
+     * @param \Magento\Catalog\Model\Product $_productItem
+     * @param string $field
+     * 
+     * @return string $websiteName
+     * 
+     */
+    protected function getWebsiteName(\Magento\Catalog\Model\Product $_productItem, string $field):string {
+        $websiteId = $this->getColumnData($_productItem,$field);
+        /** @var $_website \Magento\Store\Api\Data\WebsiteInterface */
+        $_website = $this->websiteRepository->getById($websiteId);
+        $websiteName = ($_website) ? $_website->getName() : '';
+        return $websiteName;
+    }
+
 }


### PR DESCRIPTION
Hi, **Thanks a lot for this much useful module** 👍 . BTW  (as also reported by other devs), the module exports the product attributes of type select / multiselect with option values instead of their labels. I just fixed this in this commit and **enhanced the product grid export button feature  to export the select/multiselect product attributes with their respective product option labels** instead of option values in CSV, XML and XLS. As well as also added code to **export the attribute set and web site with their attribute set name and website name**.  

**Product Grid with select / multiselect attributes**

![Just Better Product Export Grid Products-Inventory-Catalog-TD-SYNNEX-Magento-Admin](https://github.com/user-attachments/assets/bbda03d9-0303-492c-8c7e-180e76f771c0)

**Product Grid Exported as CSV with select fields option labels**

![Just Better Product Export CSV Screenshot 2024-08-24 at 2 51 57 PM](https://github.com/user-attachments/assets/4cd7ccc8-5d83-4a86-a8ea-daaa427f8130)

