### PR TITLE
fixed the error caused by referencing a non-existent array index.

### DIFF
--- a/Model/Export/MetadataProvider.php
+++ b/Model/Export/MetadataProvider.php
@@ -58,7 +58,9 @@ class MetadataProvider extends \Magento\Ui\Model\Export\MetadataProvider
 
         $config = $bookmark->getConfig();
         // Remove all invisible columns as well as ids, and actions columns.
-        $columns = array_filter($config['current']['columns'], fn($config, $key) => $config['visible'] && !in_array($key, ['ids', 'actions']), ARRAY_FILTER_USE_BOTH);;
+        $columns = array_filter($config['current']['columns'], function($column, $key) use ($config) {
+            return isset($config['current']['positions'][$key]) && $column['visible'] && !in_array($key, ['ids', 'actions']);
+        }, ARRAY_FILTER_USE_BOTH);
         // Sort by position in grid.
         uksort($columns, fn($a, $b) => $config['current']['positions'][$a] <=> $config['current']['positions'][$b]);
 


### PR DESCRIPTION
The issue arises from referencing an incorrect array index because the already deleted property is still stored in the bookmark.

![image](https://github.com/user-attachments/assets/9ab53ef1-5e22-424e-8269-0c5b9ff38d2c)