### PR TITLE
Removed time limit for streamed responses

### DIFF
--- a/Controller/Adminhtml/Export/GridToCsv.php
+++ b/Controller/Adminhtml/Export/GridToCsv.php
@@ -38,6 +38,7 @@ class GridToCsv extends Action
             'options' => [
                 'fileName' => 'export.csv',
                 'callback' => function () use ($data) {
+                    set_time_limit(0);
                     $handle = fopen('php://output', 'w');
                     try {
                         foreach ($data as $chunk) {

--- a/Controller/Adminhtml/Export/GridToJsonl.php
+++ b/Controller/Adminhtml/Export/GridToJsonl.php
@@ -40,6 +40,7 @@ class GridToJsonl extends Action
             'options' => [
                 'fileName' => 'export.jsonl',
                 'callback' => function () use ($data) {
+                    set_time_limit(0);
                     try {
                         foreach ($data as $chunk) {
                             echo $chunk;


### PR DESCRIPTION
Due to bytes being streamed constantly everyone is patient while exporting data (The default 1/2 minute time limits will not be triggered).
However the PHP execution time could still get exceeded.

After this change the php execution timeout will be disabled while streaming.
This will allow for excessively large datasets to be exported without issue